### PR TITLE
Fixes - script attribute race conditions and CORS hell

### DIFF
--- a/src/environments/development.js
+++ b/src/environments/development.js
@@ -1,0 +1,7 @@
+const basePath = ""
+
+export default {
+  basePath,
+  isProduction: false,
+  isDevelopment: true
+}

--- a/src/environments/production.js
+++ b/src/environments/production.js
@@ -1,0 +1,9 @@
+
+import { homepage } from "../../package.json"
+const basePath = homepage
+
+export default {
+  basePath,
+  isProduction: true,
+  isDevelopment: false
+}

--- a/src/environments/production.js
+++ b/src/environments/production.js
@@ -1,9 +1,12 @@
 
 import { homepage } from "../../package.json"
 const basePath = homepage
+const localPath = homepage.replace("/apps/", "/apps-mirror/")
 
 export default {
   basePath,
+  localPath,
+  separateCrossOriginRequests: true,
   isProduction: true,
   isDevelopment: false
 }

--- a/src/lib/base.js
+++ b/src/lib/base.js
@@ -11,7 +11,7 @@ class Base {
             $: $(root)
         }
         this.root.$.html("").append(html)
-        this.basePath = ENV.basePath
+        this.basePath = ENV.basePath.includes(location.host) ? ENV.basePath.replace("apps", "apps-mirror") : ENV.basePath
     }
 
     premiumWait (render) {

--- a/src/lib/base.js
+++ b/src/lib/base.js
@@ -1,5 +1,6 @@
 import $ from "jquery"
 import "./base.less"
+import ENV from 'Environment';
 
 
 class Base {
@@ -10,7 +11,7 @@ class Base {
             $: $(root)
         }
         this.root.$.html("").append(html)
-        this.basePath = document.currentScript.getAttribute("data-path")
+        this.basePath = ENV.basePath
     }
 
     premiumWait (render) {

--- a/src/lib/base.js
+++ b/src/lib/base.js
@@ -11,7 +11,7 @@ class Base {
             $: $(root)
         }
         this.root.$.html("").append(html)
-        this.basePath = ENV.basePath.includes(location.host) ? ENV.basePath.replace("apps", "apps-mirror") : ENV.basePath
+        this.basePath = (ENV.production && ENV.separateCrossOriginRequests && ENV.basePath.includes(location.host)) ? ENV.localPath : ENV.basePath
     }
 
     premiumWait (render) {

--- a/src/lib/base.js
+++ b/src/lib/base.js
@@ -1,4 +1,3 @@
-import $ from "jquery"
 import "./base.less"
 import ENV from 'Environment';
 

--- a/static/index.html
+++ b/static/index.html
@@ -4,10 +4,8 @@
     <meta charset="utf-8" />
     <title>New Zealand Herald Insights</title>
     <meta name="viewport" content="initial-scale=1,maximum-scale=1,user-scalable=no" />
-    <!-- Last updated 5 Jun 2019 -->
-    <link href="https://www.nzherald.co.nz/pb/gr/c/default/rsiZk523IG5usr/css/133eed50fe.css?v=40" rel="stylesheet">
-    <link href="https://www.nzherald.co.nz//pb/gr/p/default/rsiZk523IG5usr/style.css?v=40" rel="stylesheet">
-    <link href="https://www.nzherald.co.nz//pb/gr/c/default/rsiZk523IG5usr/svg_css/8bc35eec0e.css?v=40" rel="stylesheet">
+    <link href="./nzh-520781b01d.css" rel="stylesheet">
+    <script src="https://code.jquery.com/jquery-2.2.4.min.js" integrity="sha256-BbhdlvQf/xTY9gja0Dq3HiwQF8LaCRTXxZKRutelT44=" crossorigin="anonymous"></script>
     <link href="./embed.css" rel="stylesheet">
 </head>
 

--- a/util/embedgen.js
+++ b/util/embedgen.js
@@ -67,7 +67,6 @@ class EmbedPlugin {
                 jsContent += makeJS(root, "r")
                 jsContent += "r.setAttribute('data-targ', targ || '');"
                 jsContent += "r.setAttribute('data-params', params || '');"
-                jsContent += `r.setAttribute('data-path', '${basePath}');\n`
             }
             js.forEach((src, i) => jsContent += makeJS(src, "_" + i))
             jsContent += "})()"

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -5,6 +5,11 @@ const EmbedPlugin = require("./util/embedgen.js")
 
 // Spins up dev server with bundles using minimal template
 module.exports = merge(base, {
+    resolve: {
+        alias: {
+            Environment$: path.resolve(__dirname, "src/environments/development.js")
+        }
+    },
     mode: "development",
     output: {
         filename: "[name].dev.[hash].js"

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -7,6 +7,11 @@ const CopyWebpackPlugin = require("copy-webpack-plugin")
 
 // Post-processing and minification of bundle
 module.exports = merge(base, {
+    resolve: {
+        alias: {
+            Environment$: path.resolve(__dirname, "src/environments/production.js")
+        }
+    },
     mode: "production",
     output: {
         filename: "[name].prod.[chunkhash].js",


### PR DESCRIPTION
This fixes a couple of small structural issues.

I discovered that about half of the time data-path is null. I tried force the attribute to be set before the script is added but that did not help.

In the end I fixed this by adding an environments feature. I think this will ultimately be beneficial for other purposes - basically we can set variables in `src/environment/development.js` and `src/environment/production.js` for the different builds. The only variable I am currently setting is basePath - production sets it as the homepage from `package.json` - and this is then passed onto this.basePath.

I also ran into a mess of a CORS problem due to including an app in an iframe for the mobile app.  In short it was:

- CloudFront caches the headers sent to it by S3
- S3 only sets the CORS related headers when the request has an ORIGIN header
- Browsers only set the origin header in the request is cross domain
- The version of the app in an iframe send same domain requests and the version of the app embedded properly in the herald sends cross domain requests. So if the iframe version gets cached then the NZH version fails with CORS errors.
- CloudFront can be (and is) configured to cache and send different versions depending on the headers. This is working but it doesn't set all those headers in the vary header and chrome relies the vary header to decide whether or not to cache multiple versions. Other browsers are fine.

I have fixed this by adding another 'behaviour' to the CloudFront distro. https://insights.nzherald.co.nz/apps-mirror/* now serves the same content as https://insights.nzherald.co.nz/apps/* 

I implemented this using a lambda function on the app-mirror path that modifies the path to remove "-mirror". In order for this to work the app needs to request the apps-mirror version for same-domain requests and the apps version for cross-domain requests. Currently I am doing this in the base constructor - in a slightly fragile way - when basePath is set. 